### PR TITLE
Fix parsing of exception

### DIFF
--- a/jupyter_geppetto/utils.py
+++ b/jupyter_geppetto/utils.py
@@ -1,19 +1,33 @@
 import logging
-from zmq.utils import jsonapi
-from ipykernel.jsonutil import json_clean
-import json
+from jupyter_client import session
+# from zmq.utils import jsonapi
+# from ipykernel.jsonutil import json_clean
 
 def convertToJS(content):
-    return jsonapi.dumps(json_clean(content)).decode("utf-8")
+    return session.json_packer(content).decode("utf-8")
+    # Old way: this needs to be deleted if the above line is enough
+    # return jsonapi.dumps(json_clean(content)).decode("utf-8")
 
 def convertToPython(content):
-    return jsonapi.loads(content)
+    return session.json_unpacker(content)
+    # Old way: this needs to be deleted if the above line is enough
+    # return jsonapi.loads(content)
 
-def getJSONError(message, details):
+def exception_to_string(exc_info):
+    import IPython.core.ultratb
+    tb = IPython.core.ultratb.VerboseTB()
+    return tb.text(*exc_info)
+
+def getJSONError(message, exc_info):
     data = {}
     data['type'] = 'ERROR'
     data['message'] = message
-    data['details'] = str(details)
+
+    if isinstance(exc_info, str):
+        details = exc_info
+    else:
+        details = exception_to_string(exc_info)
+    data['details'] = details
     return data
 
 def getJSONReply():

--- a/jupyter_geppetto/utils.py
+++ b/jupyter_geppetto/utils.py
@@ -1,17 +1,17 @@
 import logging
-from jupyter_client import session
-# from zmq.utils import jsonapi
-# from ipykernel.jsonutil import json_clean
+# from jupyter_client import session
+from zmq.utils import jsonapi
+from ipykernel.jsonutil import json_clean
 
 def convertToJS(content):
-    return session.json_packer(content).decode("utf-8")
+    # return session.json_packer(content).decode("utf-8")
     # Old way: this needs to be deleted if the above line is enough
-    # return jsonapi.dumps(json_clean(content)).decode("utf-8")
+    return jsonapi.dumps(json_clean(content)).decode("utf-8")
 
 def convertToPython(content):
-    return session.json_unpacker(content)
+    # return session.json_unpacker(content)
     # Old way: this needs to be deleted if the above line is enough
-    # return jsonapi.loads(content)
+    return jsonapi.loads(content)
 
 def exception_to_string(exc_info):
     import IPython.core.ultratb

--- a/jupyter_geppetto/utils.py
+++ b/jupyter_geppetto/utils.py
@@ -13,13 +13,13 @@ def getJSONError(message, details):
     data = {}
     data['type'] = 'ERROR'
     data['message'] = message
-    data['details'] = details
-    return json.dumps(data)
+    data['details'] = str(details)
+    return data
 
 def getJSONReply():
     data = {}
     data['type'] = 'OK'
-    return json.dumps(data)
+    return data
 
 def configure_logging():
     try:


### PR DESCRIPTION
Exception was not parsed properly and it never displays in the frontend. Traceback is now parsed using an internal IPython library.

There is also an attempt to serialise/deserialise the input/output way in a better way but didn't work. Keeping it commented out in the code for now to give it a second attempt